### PR TITLE
Add documentation and manifests for adding new org members

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-member.md
+++ b/.github/ISSUE_TEMPLATE/new-member.md
@@ -1,0 +1,25 @@
+---
+name: Organization Membership Request
+about: Request membership in Crossplane Org
+title: 'MEMBERSHIP: <your-GH-handle>'
+
+---
+
+### GitHub Username
+e.g. (at)example_user
+
+### Requirements
+- [ ] I have reviewed the [community membership guidelines](https://github.com/crossplane/crossplane/blob/master/GOVERNANCE.md#organization-members)
+- [ ] I have [enabled 2FA](https://github.com/settings/security) on my GitHub account
+- [ ] I have joined the [Crossplane slack channel](https://slack.crossplane.io/)
+- [ ] I am actively contributing to the Crossplane project
+- [ ] I have two sponsors that are current Crossplane Org members
+- [ ] I have spoken to my sponsors ahead of this application, and they have agreed to sponsor my application
+
+### Sponsors
+- (at)sponsor-1
+- (at)sponsor-2
+
+### List of contributions to the Crossplane project
+- PRs reviewed / authored
+- Issues responded to

--- a/config/members-crossplane.yaml
+++ b/config/members-crossplane.yaml
@@ -1,0 +1,311 @@
+apiVersion: organizations.github.crossplane.io/v1alpha1
+kind: Membership
+metadata:
+  name: crossplane-bassam
+  labels:
+    org: crossplane
+spec:
+  forProvider:
+    inviteeId: 1463491
+    user: bassam
+    organization: crossplane
+    role: admin
+---
+apiVersion: organizations.github.crossplane.io/v1alpha1
+kind: Membership
+metadata:
+  name: crossplane-chrisupbound
+  labels:
+    org: crossplane
+spec:
+  forProvider:
+    inviteeId: 45638242
+    user: Chrisupbound
+    organization: crossplane
+    role: direct_member
+---
+apiVersion: organizations.github.crossplane.io/v1alpha1
+kind: Membership
+metadata:
+  name: crossplane-connorchan
+  labels:
+    org: crossplane
+spec:
+  forProvider:
+    inviteeId: 8014678
+    user: connorchan
+    organization: crossplane
+    role: direct_member
+---
+apiVersion: organizations.github.crossplane.io/v1alpha1
+kind: Membership
+metadata:
+  name: crossplane-davetorbeck
+  labels:
+    org: crossplane
+spec:
+  forProvider:
+    inviteeId: 5829885
+    user: davetorbeck
+    organization: crossplane
+    role: direct_member
+---
+apiVersion: organizations.github.crossplane.io/v1alpha1
+kind: Membership
+metadata:
+  name: crossplane-defilan
+  labels:
+    org: crossplane
+spec:
+  forProvider:
+    inviteeId: 7034124
+    user: Defilan
+    organization: crossplane
+    role: direct_member
+---
+apiVersion: organizations.github.crossplane.io/v1alpha1
+kind: Membership
+metadata:
+  name: crossplane-displague
+  labels:
+    org: crossplane
+spec:
+  forProvider:
+    inviteeId: 317653
+    user: displague
+    organization: crossplane
+    role: direct_member
+---
+apiVersion: organizations.github.crossplane.io/v1alpha1
+kind: Membership
+metadata:
+  name: crossplane-gauravgahlot
+  labels:
+    org: crossplane
+spec:
+  forProvider:
+    inviteeId: 28539256
+    user: gauravgahlot
+    organization: crossplane
+    role: direct_member
+---
+apiVersion: organizations.github.crossplane.io/v1alpha1
+kind: Membership
+metadata:
+  name: crossplane-grantgumina
+  labels:
+    org: crossplane
+spec:
+  forProvider:
+    inviteeId: 372681
+    user: grantgumina
+    organization: crossplane
+    role: direct_member
+---
+apiVersion: organizations.github.crossplane.io/v1alpha1
+kind: Membership
+metadata:
+  name: crossplane-hasheddan
+  labels:
+    org: crossplane
+spec:
+  forProvider:
+    inviteeId: 31777345
+    user: hasheddan
+    organization: crossplane
+    role: direct_member
+---
+apiVersion: organizations.github.crossplane.io/v1alpha1
+kind: Membership
+metadata:
+  name: crossplane-hongchaodeng
+  labels:
+    org: crossplane
+spec:
+  forProvider:
+    inviteeId: 920884
+    user: hongchaodeng
+    organization: crossplane
+    role: direct_member
+---
+apiVersion: organizations.github.crossplane.io/v1alpha1
+kind: Membership
+metadata:
+  name: crossplane-ichekrygin
+  labels:
+    org: crossplane
+spec:
+  forProvider:
+    inviteeId: 324803
+    user: ichekrygin
+    organization: crossplane
+    role: direct_member
+---
+apiVersion: organizations.github.crossplane.io/v1alpha1
+kind: Membership
+metadata:
+  name: crossplane-infinitecompute
+  labels:
+    org: crossplane
+spec:
+  forProvider:
+    inviteeId: 40583244
+    user: infinitecompute
+    organization: crossplane
+    role: direct_member
+---
+apiVersion: organizations.github.crossplane.io/v1alpha1
+kind: Membership
+metadata:
+  name: crossplane-jbw976
+  labels:
+    org: crossplane
+spec:
+  forProvider:
+    inviteeId: 4313439
+    user: jbw976
+    organization: crossplane
+    role: admin
+---
+apiVersion: organizations.github.crossplane.io/v1alpha1
+kind: Membership
+metadata:
+  name: crossplane-kasey
+  labels:
+    org: crossplane
+spec:
+  forProvider:
+    inviteeId: 489222
+    user: kasey
+    organization: crossplane
+    role: direct_member
+---
+apiVersion: organizations.github.crossplane.io/v1alpha1
+kind: Membership
+metadata:
+  name: crossplane-krishchow
+  labels:
+    org: crossplane
+spec:
+  forProvider:
+    inviteeId: 28268846
+    user: krishchow
+    organization: crossplane
+    role: direct_member
+---
+apiVersion: organizations.github.crossplane.io/v1alpha1
+kind: Membership
+metadata:
+  name: crossplane-lukeweber
+  labels:
+    org: crossplane
+spec:
+  forProvider:
+    inviteeId: 195363
+    user: lukeweber
+    organization: crossplane
+    role: direct_member
+---
+apiVersion: organizations.github.crossplane.io/v1alpha1
+kind: Membership
+metadata:
+  name: crossplane-muvaf
+  labels:
+    org: crossplane
+spec:
+  forProvider:
+    inviteeId: 7584126
+    user: muvaf
+    organization: crossplane
+    role: direct_member
+---
+apiVersion: organizations.github.crossplane.io/v1alpha1
+kind: Membership
+metadata:
+  name: crossplane-negz
+  labels:
+    org: crossplane
+spec:
+  forProvider:
+    inviteeId: 1049349
+    user: negz
+    organization: crossplane
+    role: admin
+---
+apiVersion: organizations.github.crossplane.io/v1alpha1
+kind: Membership
+metadata:
+  name: crossplane-prasek
+  labels:
+    org: crossplane
+spec:
+  forProvider:
+    inviteeId: 284840
+    user: prasek
+    organization: crossplane
+    role: direct_member
+---
+apiVersion: organizations.github.crossplane.io/v1alpha1
+kind: Membership
+metadata:
+  name: crossplane-rathpc
+  labels:
+    org: crossplane
+spec:
+  forProvider:
+    inviteeId: 5623579
+    user: rathpc
+    organization: crossplane
+    role: direct_member
+---
+apiVersion: organizations.github.crossplane.io/v1alpha1
+kind: Membership
+metadata:
+  name: crossplane-suskin
+  labels:
+    org: crossplane
+spec:
+  forProvider:
+    inviteeId: 813571
+    user: suskin
+    organization: crossplane
+    role: direct_member
+---
+apiVersion: organizations.github.crossplane.io/v1alpha1
+kind: Membership
+metadata:
+  name: crossplane-thephred
+  labels:
+    org: crossplane
+spec:
+  forProvider:
+    inviteeId: 110422
+    user: thephred
+    organization: crossplane
+    role: direct_member
+---
+apiVersion: organizations.github.crossplane.io/v1alpha1
+kind: Membership
+metadata:
+  name: crossplane-turkenh
+  labels:
+    org: crossplane
+spec:
+  forProvider:
+    inviteeId: 9900707
+    user: turkenh
+    organization: crossplane
+    role: direct_member
+---
+apiVersion: organizations.github.crossplane.io/v1alpha1
+kind: Membership
+metadata:
+  name: crossplane-wonderflow
+  labels:
+    org: crossplane
+spec:
+  forProvider:
+    inviteeId: 2173670
+    user: wonderflow
+    organization: crossplane
+    role: direct_member

--- a/processes/new-member.md
+++ b/processes/new-member.md
@@ -1,0 +1,19 @@
+# Adding a New Member to the Crossplane Org
+
+For new members to be added to the Crossplane Org, the candidate must open an
+issue using the the [New Member
+template](../.github/ISSUE_TEMPLATE/new-member.md) after they have spoken to two
+current Org members who have agreed to sponsor their membership request.
+
+After the issue has been opened, each sponsor must comment with a `+1`
+indicating they agree to sponsor the membership request. When both members have
+commented, either of them, or any other Org member, may open a pull request to
+the [crossplane/org](https://github.com/crossplane/org) repository, adding that
+member to the
+[config/members-crossplane.yaml](../config/members-crossplane.yaml) file.
+
+The pull request must be approved and merged by a member of the [Crossplane
+steering
+committee](https://github.com/crossplane/crossplane/blob/master/GOVERNANCE.md#steering-committee),
+at which point the CI GitHub actions on the repo will automatically invite the
+user to be a member in the Org.


### PR DESCRIPTION
Adds documentation and an issue template for adding new members to the Crossplane org. Also introduces `Membership` manifests that will be reconciled by `provider-github`. You can see this in action on recent [CrossHack stream](https://youtu.be/osrUo-7Twz0) -- note that this is not enabled yet, this is just adding the manifests so we can start adding new members to the org via this process (+ the current manual step) while the org cluster is being set up.

Also note that the manifests contain only 24/40 members because some members have chosen to mark their membership as private. This is fine from a reconciliation perspective because provider-github will have credentials to view the private members, but out of an abundance of caution I didn't want to reflect those private members in this public repository until we can either verify that it is acceptable to do so and / or have them flip their membership to public.

Fixes #1 