### PR TITLE
Add rahulgrover99 as new member

### DIFF
--- a/config/members-crossplane.yaml
+++ b/config/members-crossplane.yaml
@@ -248,6 +248,19 @@ spec:
 apiVersion: organizations.github.crossplane.io/v1alpha1
 kind: Membership
 metadata:
+  name: crossplane-rahulgrover99
+  labels:
+    org: crossplane
+spec:
+  forProvider:
+    inviteeId: 32982944
+    user: rahulgrover99
+    organization: crossplane
+    role: direct_member
+---
+apiVersion: organizations.github.crossplane.io/v1alpha1
+kind: Membership
+metadata:
   name: crossplane-rathpc
   labels:
     org: crossplane


### PR DESCRIPTION
Adds @rahulgrover99 as a new member in the Crossplane org.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Fixes #4 

@jbw976 since the org cluster is not setup yet, we'll still need you to manually add @rahulgrover99.