### PR TITLE
add tnthornton as a member

### DIFF
--- a/config/members-crossplane.yaml
+++ b/config/members-crossplane.yaml
@@ -313,6 +313,19 @@ spec:
 apiVersion: organizations.github.crossplane.io/v1alpha1
 kind: Membership
 metadata:
+  name: crossplane-tnthornton
+  labels:
+    org: crossplane
+spec:
+  forProvider:
+    inviteeId: 2375126
+    user: tnthornton
+    organization: crossplane
+    role: direct_member
+---
+apiVersion: organizations.github.crossplane.io/v1alpha1
+kind: Membership
+metadata:
   name: crossplane-turkenh
   labels:
     org: crossplane


### PR DESCRIPTION
This PR adds @tnthornton as a member to the crossplane org.

Fixes #12,  following the new member process in https://github.com/crossplane/org/blob/main/processes/new-member.md.