### PR TITLE
Add @Feggah as crossplane org member

### DIFF
--- a/config/members-crossplane.yaml
+++ b/config/members-crossplane.yaml
@@ -105,6 +105,19 @@ spec:
 apiVersion: organizations.github.crossplane.io/v1alpha1
 kind: Membership
 metadata:
+  name: crossplane-feggah
+  labels:
+    org: crossplane
+spec:
+  forProvider:
+    inviteeId: 11353912
+    user: Feggah
+    organization: crossplane
+    role: direct_member
+---
+apiVersion: organizations.github.crossplane.io/v1alpha1
+kind: Membership
+metadata:
   name: crossplane-gauravgahlot
   labels:
     org: crossplane


### PR DESCRIPTION
Adds @Feggah as a member of the crossplane organization.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Fixes #18 

> Note: requires steering committee approval (cc @jbw976 @negz)