### PR TITLE
Add @haarchri as a member

### DIFF
--- a/config/members-crossplane.yaml
+++ b/config/members-crossplane.yaml
@@ -144,6 +144,19 @@ spec:
 apiVersion: organizations.github.crossplane.io/v1alpha1
 kind: Membership
 metadata:
+  name: crossplane-haarchri
+  labels:
+    org: crossplane
+spec:
+  forProvider:
+    inviteeId: 21083497
+    user: haarchri
+    organization: crossplane
+    role: direct_member
+---
+apiVersion: organizations.github.crossplane.io/v1alpha1
+kind: Membership
+metadata:
   name: crossplane-hasheddan
   labels:
     org: crossplane


### PR DESCRIPTION
This PR adds @haarchri as a member of the Crossplane organization.

User ID obtained from https://api.github.com/users/haarchri

Fixes #20 