### PR TITLE
Add Ruhika1417 to org membership

### DIFF
--- a/config/members-crossplane.yaml
+++ b/config/members-crossplane.yaml
@@ -365,6 +365,19 @@ spec:
 apiVersion: organizations.github.crossplane.io/v1alpha1
 kind: Membership
 metadata:
+  name: crossplane-Ruhika1417
+  labels:
+    org: crossplane
+spec:
+  forProvider:
+    inviteeId: 65492460
+    user: Ruhika1417
+    organization: crossplane
+    role: direct_member
+---
+apiVersion: organizations.github.crossplane.io/v1alpha1
+kind: Membership
+metadata:
   name: crossplane-sergenyalcin
   labels:
     org: crossplane


### PR DESCRIPTION
This PR adds @Ruhika1417 as a member of the Crossplane organization, as per the request in #33.

User data retrieved from https://api.github.com/users/Ruhika1417.
