### PR TITLE
add @parul5sahoo and @avalanche123 as Crossplane org members

### DIFF
--- a/config/members-crossplane.yaml
+++ b/config/members-crossplane.yaml
@@ -14,6 +14,19 @@ spec:
 apiVersion: organizations.github.crossplane.io/v1alpha1
 kind: Membership
 metadata:
+  name: crossplane-avalanche123
+  labels:
+    org: crossplane
+spec:
+  forProvider:
+    inviteeId: 83289
+    user: avalanche123
+    organization: crossplane
+    role: direct_member
+---
+apiVersion: organizations.github.crossplane.io/v1alpha1
+kind: Membership
+metadata:
   name: crossplane-bassam
   labels:
     org: crossplane
@@ -322,6 +335,19 @@ spec:
     user: negz
     organization: crossplane
     role: admin
+---
+apiVersion: organizations.github.crossplane.io/v1alpha1
+kind: Membership
+metadata:
+  name: crossplane-parul5sahoo
+  labels:
+    org: crossplane
+spec:
+  forProvider:
+    inviteeId: 60248260
+    user: parul5sahoo
+    organization: crossplane
+    role: direct_member
 ---
 apiVersion: organizations.github.crossplane.io/v1alpha1
 kind: Membership


### PR DESCRIPTION
This PR adds the following contributors as new members in the Crossplane org:

* @parul5sahoo
* @avalanche123

Fixes #35 and #36

Member IDs obtained from https://api.github.com/users/parul5sahoo and https://api.github.com/users/avalanche123.