### PR TITLE
add pedjak as a member

### DIFF
--- a/config/members-crossplane.yaml
+++ b/config/members-crossplane.yaml
@@ -495,6 +495,19 @@ spec:
 apiVersion: organizations.github.crossplane.io/v1alpha1
 kind: Membership
 metadata:
+  name: crossplane-pedjak
+  labels:
+    org: crossplane
+spec:
+  forProvider:
+    inviteeId: 132690
+    user: pedjak
+    organization: crossplane
+    role: direct_member
+---
+apiVersion: organizations.github.crossplane.io/v1alpha1
+kind: Membership
+metadata:
   name: crossplane-phisco
   labels:
     org: crossplane


### PR DESCRIPTION
This PR adds @pedjak as a member to the Crossplane org.

Fixes #61 

Github user ID obtained from https://api.github.com/users/pedjak.