### PR TITLE
Add elohmrow as member

### DIFF
--- a/config/members-crossplane.yaml
+++ b/config/members-crossplane.yaml
@@ -144,6 +144,19 @@ spec:
 apiVersion: organizations.github.crossplane.io/v1alpha1
 kind: Membership
 metadata:
+  name: crossplane-elohmrow
+  labels:
+    org: crossplane
+spec:
+  forProvider:
+    inviteeId: 1139586
+    user: elohmrow
+    organization: crossplane
+    role: direct_member
+---
+apiVersion: organizations.github.crossplane.io/v1alpha1
+kind: Membership
+metadata:
   name: crossplane-epk
   labels:
     org: crossplane


### PR DESCRIPTION
This PR adds @elohmrow as a member to the crossplane org.

Github user ID was obtained from https://api.github.com/users/elohmrow

Fixes #54 