### PR TITLE
Add dee0sap to org as member

### DIFF
--- a/config/members-crossplane.yaml
+++ b/config/members-crossplane.yaml
@@ -118,6 +118,19 @@ spec:
 apiVersion: organizations.github.crossplane.io/v1alpha1
 kind: Membership
 metadata:
+  name: crossplane-dee0sap
+  labels:
+    org: crossplane
+spec:
+  forProvider:
+    inviteeId: 82829708
+    user: dee0sap
+    organization: crossplane
+    role: direct_member
+---
+apiVersion: organizations.github.crossplane.io/v1alpha1
+kind: Membership
+metadata:
   name: crossplane-defilan
   labels:
     org: crossplane


### PR DESCRIPTION
This PR adds @dee0sap as a member to the Crossplane organization.

User ID obtained from https://api.github.com/users/dee0sap

Fixes #67 