### PR TITLE
add adamwg and n3wscott as members

### DIFF
--- a/config/members-crossplane.yaml
+++ b/config/members-crossplane.yaml
@@ -27,6 +27,19 @@ spec:
 apiVersion: organizations.github.crossplane.io/v1alpha1
 kind: Membership
 metadata:
+  name: crossplane-adamwg
+  labels:
+    org: crossplane
+spec:
+  forProvider:
+    inviteeId: 414574
+    user: adamwg
+    organization: crossplane
+    role: direct_member
+---
+apiVersion: organizations.github.crossplane.io/v1alpha1
+kind: Membership
+metadata:
   name: crossplane-AlainRoy
   labels:
     org: crossplane
@@ -515,6 +528,19 @@ spec:
   forProvider:
     inviteeId: 15015463
     user: MisterMX
+    organization: crossplane
+    role: direct_member
+---
+apiVersion: organizations.github.crossplane.io/v1alpha1
+kind: Membership
+metadata:
+  name: crossplane-n3wscott
+  labels:
+    org: crossplane
+spec:
+  forProvider:
+    inviteeId: 32305648
+    user: n3wscott
     organization: crossplane
     role: direct_member
 ---


### PR DESCRIPTION
This PR adds @adamwg and @n3wscott as members of the Crossplane organization.

Fixes https://github.com/crossplane/org/issues/90
Fixes https://github.com/crossplane/org/issues/91

Member IDs retrieved from https://api.github.com/users/adamwg and https://api.github.com/users/n3wscott.

Invitations will be sent when this PR has been merged.