### PR TITLE
add gaiters-cafes as member

### DIFF
--- a/config/members-crossplane.yaml
+++ b/config/members-crossplane.yaml
@@ -261,6 +261,19 @@ spec:
 apiVersion: organizations.github.crossplane.io/v1alpha1
 kind: Membership
 metadata:
+  name: crossplane-gaiters-cafes
+  labels:
+    org: crossplane
+spec:
+  forProvider:
+    inviteeId: 119340735
+    user: gaiters-cafes
+    organization: crossplane
+    role: direct_member
+---
+apiVersion: organizations.github.crossplane.io/v1alpha1
+kind: Membership
+metadata:
   name: crossplane-gauravgahlot
   labels:
     org: crossplane


### PR DESCRIPTION
This PR adds @gaiters-cafes as a member in the Crossplane organization.  Member ID obtained from https://api.github.com/users/gaiters-cafes.

Fixes #97 