### PR TITLE
chore: add kaessert to org members

### DIFF
--- a/config/members-crossplane.yaml
+++ b/config/members-crossplane.yaml
@@ -456,6 +456,19 @@ spec:
 apiVersion: organizations.github.crossplane.io/v1alpha1
 kind: Membership
 metadata:
+  name: crossplane-kaessert
+  labels:
+    org: crossplane
+spec:
+  forProvider:
+    inviteeId: 339932
+    user: kaessert
+    organization: crossplane
+    role: direct_member
+---
+apiVersion: organizations.github.crossplane.io/v1alpha1
+kind: Membership
+metadata:
   name: crossplane-kasey
   labels:
     org: crossplane


### PR DESCRIPTION
This PR adds @kaessert to the Crossplane organization members.

Member ID obtained from https://api.github.com/users/kaessert

Fixes https://github.com/crossplane/org/issues/107